### PR TITLE
Support batched writes

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -811,6 +811,11 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   }
 
   @Override
+  public int getBatchInsertSize() {
+    return Integer.parseInt(getParameter(DatabricksJdbcUrlParams.BATCH_INSERT_SIZE));
+  }
+
+  @Override
   public boolean isTelemetryEnabled() {
     return getParameter(DatabricksJdbcUrlParams.ENABLE_TELEMETRY).equals("1");
   }

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
@@ -154,22 +154,27 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
     try {
       InsertStatementParser.InsertInfo insertInfo = InsertStatementParser.parseInsertStrict(sql);
 
-      // Calculate how many rows we can fit in one chunk based on parameter limit
+      // Calculate how many rows we can fit in one chunk
       int parametersPerRow = insertInfo.getColumnCount();
       int maxRowsPerChunk;
 
       if (interpolateParameters) {
         // When parameter interpolation is enabled (supportManyParameters=1), there is no
         // parameter limit since values are interpolated directly into the SQL string.
-        // Execute all rows in a single batch for optimal performance.
-        maxRowsPerChunk = databricksBatchParameterMetaData.size();
+        // Try to execute all rows in a single batch, only limited by configured BatchInsertSize
+        // which users can set based on their data to avoid exceeding the 16MB statement limit.
+        int configuredBatchSize = connection.getConnectionContext().getBatchInsertSize();
+        maxRowsPerChunk = Math.min(configuredBatchSize, databricksBatchParameterMetaData.size());
       } else {
         // When using parameterized queries, respect the 256 parameter limit from Databricks backend
-        maxRowsPerChunk = DatabricksJdbcConstants.MAX_QUERY_PARAMETERS / parametersPerRow;
+        int maxRowsByParameterLimit =
+            DatabricksJdbcConstants.MAX_QUERY_PARAMETERS / parametersPerRow;
 
         // Ensure we have at least 1 row per chunk
-        if (maxRowsPerChunk < 1) {
+        if (maxRowsByParameterLimit < 1) {
           maxRowsPerChunk = 1;
+        } else {
+          maxRowsPerChunk = maxRowsByParameterLimit;
         }
       }
 

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
@@ -156,11 +156,21 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
 
       // Calculate how many rows we can fit in one chunk based on parameter limit
       int parametersPerRow = insertInfo.getColumnCount();
-      int maxRowsPerChunk = DatabricksJdbcConstants.MAX_QUERY_PARAMETERS / parametersPerRow;
+      int maxRowsPerChunk;
 
-      // Ensure we have at least 1 row per chunk
-      if (maxRowsPerChunk < 1) {
-        maxRowsPerChunk = 1;
+      if (interpolateParameters) {
+        // When parameter interpolation is enabled (supportManyParameters=1), there is no
+        // parameter limit since values are interpolated directly into the SQL string.
+        // Execute all rows in a single batch for optimal performance.
+        maxRowsPerChunk = databricksBatchParameterMetaData.size();
+      } else {
+        // When using parameterized queries, respect the 256 parameter limit from Databricks backend
+        maxRowsPerChunk = DatabricksJdbcConstants.MAX_QUERY_PARAMETERS / parametersPerRow;
+
+        // Ensure we have at least 1 row per chunk
+        if (maxRowsPerChunk < 1) {
+          maxRowsPerChunk = 1;
+        }
       }
 
       long[] allUpdateCounts = new long[databricksBatchParameterMetaData.size()];
@@ -193,8 +203,12 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
           }
         }
 
-        // Execute this chunk
-        executeInternal(multiRowSql, chunkParams, StatementType.UPDATE, false);
+        // Execute this chunk with interpolation if enabled
+        String sqlToExecute =
+            interpolateParameters ? interpolateSQL(multiRowSql, chunkParams) : multiRowSql;
+        Map<Integer, ImmutableSqlParameter> paramsToSend =
+            interpolateParameters ? new HashMap<>() : chunkParams;
+        executeInternal(sqlToExecute, paramsToSend, StatementType.UPDATE, false);
 
         // Set update counts for this chunk (each row typically affects 1 row)
         for (int i = startIndex; i < endIndex; i++) {

--- a/src/main/java/com/databricks/jdbc/api/internal/IDatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/internal/IDatabricksConnectionContext.java
@@ -268,6 +268,9 @@ public interface IDatabricksConnectionContext {
   /** Returns the batch size for Telemetry logs processing */
   int getTelemetryBatchSize();
 
+  /** Returns the maximum number of rows per batch insert execution */
+  int getBatchInsertSize();
+
   /**
    * Returns a unique identifier for this connection context.
    *

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -95,6 +95,7 @@ public enum DatabricksJdbcUrlParams {
       "1"), // Note : telemetry enablement also depends on the server flag.
   TELEMETRY_BATCH_SIZE("TelemetryBatchSize", "Batch size for telemetry", "200"),
   MAX_BATCH_SIZE("MaxBatchSize", "Maximum batch size", "500"),
+  BATCH_INSERT_SIZE("BatchInsertSize", "Maximum number of rows per batch insert execution", "1000"),
   ALLOWED_VOLUME_INGESTION_PATHS("VolumeOperationAllowedLocalPaths", ""),
   ALLOWED_STAGING_INGESTION_PATHS("StagingAllowedLocalPaths", ""),
   UC_INGESTION_RETRIABLE_HTTP_CODE(

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
@@ -7,6 +7,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
@@ -995,5 +997,103 @@ public class DatabricksPreparedStatementTest {
     for (int count : updateCounts) {
       assertEquals(1, count); // Each row should show 1 row affected
     }
+  }
+
+  @Test
+  public void testBatchedInsertWithCustomBatchInsertSize() throws Exception {
+    // Test that BatchInsertSize parameter controls chunking behavior
+    // With 8 columns and BatchInsertSize=50, max 50 rows per chunk
+    String jdbcUrlWithCustomBatchSize =
+        JDBC_URL_WITH_MANY_PARAMETERS + "EnableBatchedInserts=1;BatchInsertSize=50;";
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(jdbcUrlWithCustomBatchSize, new Properties());
+    DatabricksConnection connection = new DatabricksConnection(connectionContext, client);
+    DatabricksPreparedStatement statement =
+        new DatabricksPreparedStatement(connection, BATCH_STATEMENT);
+
+    // Add 200 rows, which should be split into 4 chunks of 50 rows each
+    for (int i = 1; i <= 200; i++) {
+      statement.setLong(1, 100 + i);
+      statement.setShort(2, (short) (10 + i));
+      statement.setByte(3, (byte) (i % 128));
+      statement.setString(4, "value" + i);
+      statement.addBatch();
+    }
+
+    // Verify BatchInsertSize is read correctly
+    assertEquals(50, connectionContext.getBatchInsertSize());
+
+    // Mock will be called 4 times (200 rows / 50 batch size = 4 chunks)
+    String expectedSqlPrefix = "INSERT INTO orders (user_id, shard, region_code, namespace) VALUES";
+    when(client.executeStatement(
+            org.mockito.ArgumentMatchers.startsWith(expectedSqlPrefix),
+            eq(new Warehouse(WAREHOUSE_ID)),
+            any(HashMap.class),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement)))
+        .thenReturn(resultSet);
+    lenient().when(resultSet.getUpdateCount()).thenReturn(50L);
+
+    int[] updateCounts = statement.executeBatch();
+    assertEquals(200, updateCounts.length);
+    for (int count : updateCounts) {
+      assertEquals(1, count); // Each row should show 1 row affected
+    }
+
+    // CRITICAL: Verify that executeStatement was called exactly 4 times (4 chunks of 50 rows)
+    verify(client, times(4))
+        .executeStatement(
+            org.mockito.ArgumentMatchers.startsWith(expectedSqlPrefix),
+            eq(new Warehouse(WAREHOUSE_ID)),
+            any(HashMap.class),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement));
+  }
+
+  @Test
+  public void testBatchInsertSizeDefaultValue() throws Exception {
+    // Test that BatchInsertSize defaults to 1000 when not specified
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL_WITH_BATCHED_INSERTS, new Properties());
+    assertEquals(1000, connectionContext.getBatchInsertSize());
+  }
+
+  @Test
+  public void testBatchInsertSizeRespectsParameterLimit() throws Exception {
+    // Test that without supportManyParameters, the driver still respects 256 parameter limit
+    // even if BatchInsertSize is higher
+    String jdbcUrlWithHighBatchSize = JDBC_URL_WITH_BATCHED_INSERTS + "BatchInsertSize=5000;";
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(jdbcUrlWithHighBatchSize, new Properties());
+    DatabricksConnection connection = new DatabricksConnection(connectionContext, client);
+    DatabricksPreparedStatement statement =
+        new DatabricksPreparedStatement(connection, BATCH_STATEMENT);
+
+    // Add 100 rows with 4 columns = 400 parameters (exceeds 256 limit)
+    for (int i = 1; i <= 100; i++) {
+      statement.setLong(1, 100 + i);
+      statement.setShort(2, (short) (10 + i));
+      statement.setByte(3, (byte) (i % 128));
+      statement.setString(4, "value" + i);
+      statement.addBatch();
+    }
+
+    // Without supportManyParameters, should chunk at 256/4 = 64 rows
+    // even though BatchInsertSize=5000
+    String expectedSqlPrefix = "INSERT INTO orders (user_id, shard, region_code, namespace) VALUES";
+    when(client.executeStatement(
+            org.mockito.ArgumentMatchers.startsWith(expectedSqlPrefix),
+            eq(new Warehouse(WAREHOUSE_ID)),
+            any(HashMap.class),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement)))
+        .thenReturn(resultSet);
+    lenient().when(resultSet.getUpdateCount()).thenReturn(64L);
+
+    int[] updateCounts = statement.executeBatch();
+    assertEquals(100, updateCounts.length);
   }
 }

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
@@ -915,4 +915,85 @@ public class DatabricksPreparedStatementTest {
         DatabricksSQLException.class,
         () -> preparedStatement.execute("SELECT * FROM table", new String[] {"column"}));
   }
+
+  @Test
+  public void testBatchedInsertWithManyParameters() throws Exception {
+    // Test that when supportManyParameters=1, batched inserts can exceed 256 parameters
+    // by using parameter interpolation instead of parameterized queries
+    String jdbcUrlWithBothFlags = JDBC_URL_WITH_MANY_PARAMETERS + "EnableBatchedInserts=1;";
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(jdbcUrlWithBothFlags, new Properties());
+    DatabricksConnection connection = new DatabricksConnection(connectionContext, client);
+    DatabricksPreparedStatement statement =
+        new DatabricksPreparedStatement(connection, BATCH_STATEMENT);
+
+    // Add 200 rows with 4 parameters each = 800 parameters (exceeds 256 limit)
+    for (int i = 1; i <= 200; i++) {
+      statement.setLong(1, 100 + i);
+      statement.setShort(2, (short) (10 + i));
+      statement.setByte(3, (byte) (i % 128));
+      statement.setString(4, "value" + i);
+      statement.addBatch();
+    }
+
+    // With supportManyParameters=1, all 200 rows should be batched in a single INSERT
+    // with interpolated values (not parameterized)
+    String expectedSqlPrefix = "INSERT INTO orders (user_id, shard, region_code, namespace) VALUES";
+    when(client.executeStatement(
+            org.mockito.ArgumentMatchers.startsWith(expectedSqlPrefix),
+            eq(new Warehouse(WAREHOUSE_ID)),
+            any(HashMap.class),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement)))
+        .thenReturn(resultSet);
+    lenient().when(resultSet.getUpdateCount()).thenReturn(200L);
+
+    int[] updateCounts = statement.executeBatch();
+    assertEquals(200, updateCounts.length);
+    for (int count : updateCounts) {
+      assertEquals(1, count); // Each row should show 1 row affected
+    }
+  }
+
+  @Test
+  public void testBatchedInsertWithVeryLargeParameterCount() throws Exception {
+    // Test with 10,000 rows = 40,000 parameters to verify scalability
+    // This would require ~156 chunks with the old 256-parameter limit
+    // but now executes as a single batch with parameter interpolation
+    String jdbcUrlWithBothFlags = JDBC_URL_WITH_MANY_PARAMETERS + "EnableBatchedInserts=1;";
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(jdbcUrlWithBothFlags, new Properties());
+    DatabricksConnection connection = new DatabricksConnection(connectionContext, client);
+    DatabricksPreparedStatement statement =
+        new DatabricksPreparedStatement(connection, BATCH_STATEMENT);
+
+    // Add 10,000 rows with 4 parameters each = 40,000 parameters
+    int rowCount = 10000;
+    for (int i = 1; i <= rowCount; i++) {
+      statement.setLong(1, 100 + i);
+      statement.setShort(2, (short) (10 + (i % 1000)));
+      statement.setByte(3, (byte) (i % 128));
+      statement.setString(4, "value" + i);
+      statement.addBatch();
+    }
+
+    // With supportManyParameters=1, all 10,000 rows execute in a single INSERT
+    String expectedSqlPrefix = "INSERT INTO orders (user_id, shard, region_code, namespace) VALUES";
+    when(client.executeStatement(
+            org.mockito.ArgumentMatchers.startsWith(expectedSqlPrefix),
+            eq(new Warehouse(WAREHOUSE_ID)),
+            any(HashMap.class),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement)))
+        .thenReturn(resultSet);
+    lenient().when(resultSet.getUpdateCount()).thenReturn((long) rowCount);
+
+    int[] updateCounts = statement.executeBatch();
+    assertEquals(rowCount, updateCounts.length);
+    for (int count : updateCounts) {
+      assertEquals(1, count); // Each row should show 1 row affected
+    }
+  }
 }


### PR DESCRIPTION
## Description

Added a new `BATCH_INSERT_SIZE` parameter that controls the number of rows to batch while performing an insert.
We were previously limited to `256 Parameters` which was not very performant for large numbers of writes.

By calling the `interpolateParameters` method, (which is flagged off by supportManyParameters), we are able to write larger batches of records. Setting the default value to 1000 rows is meant to be conservative and should prevent users from hitting the max payload size. 

```
Error : com.databricks.internal.sdk.core.error.platform.InvalidParameterValue: The statement field must not exceed a length of 16777216 bytes.
```

## Testing

Additional unit tests that verify the batching of records.
Local behavior verification and - writing to databricks via jdbc.

## Additional Notes to the Reviewer

You currently need the following parameters to enable this behavior:

`supportManyParameters=1` + `EnableBatchedInserts=1` + `BatchInsertSize=5000`

There is an existing `MAX_BATCH_SIZE` which is used by similar code, but I think they are separate use cases that warrant different parameters.
